### PR TITLE
descriptor text not nested in descriptor search

### DIFF
--- a/alps_siren.asciidoc
+++ b/alps_siren.asciidoc
@@ -142,8 +142,9 @@ ALPS profile to a Siren representation is rather straightforward.
 ----
 <alps>
   <link rel="self" href="http://alps.io/profiles/search" />
-  <descriptor id="text" type="semantic" />
-  <descriptor id="search" type="safe" />
+  <descriptor id="search" type="safe" >
+    <descriptor id="text" type="semantic" />
+  </descriptor>
 </alps>
 ----
 


### PR DESCRIPTION
In http://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-01#section-1.3 you see that input control descriptors are nested inside state transition descriptors:

```
 <!-- a hypermedia control for returning contacts -->
 <descriptor id="collection" type="safe" rt="contact">
   <doc>
     A simple link/form for getting a list of contacts.
   </doc>
   <descriptor id="nameSearch" type="semantic">
     <doc>Input for a search form.</doc>
   </descriptor>
 </descriptor>
```
